### PR TITLE
More flexible composition of views for RustBoyButton

### DIFF
--- a/CommonUI/DPad.swift
+++ b/CommonUI/DPad.swift
@@ -16,9 +16,10 @@ internal struct DPad: View {
 
 		GeometryReader { geometry in
 			ZStack {
-				HalfPad(types: (.left, .right), rustBoy: self.rustBoy)
+                HalfPad(firstButtonType: .left, secondButtonType: .right, rustBoy: self.rustBoy)
 					.frame(height: min(geometry.size.height, geometry.size.width) / 3)
-				HalfPad(types: (.up, .down), rustBoy: self.rustBoy)
+
+                HalfPad(firstButtonType: .up, secondButtonType: .down, rustBoy: self.rustBoy)
 					.frame(height: min(geometry.size.height, geometry.size.width) / 3)
 					.rotationEffect(.degrees(90))
 			}
@@ -33,13 +34,14 @@ internal struct DPad: View {
 
 fileprivate struct HalfPad: View {
 
-	fileprivate let types: (RustBoy.ButtonType, RustBoy.ButtonType)
+	fileprivate let firstButtonType: RustBoy.ButtonType
+    fileprivate let secondButtonType: RustBoy.ButtonType
 	fileprivate let rustBoy: RustBoy
 
 	fileprivate var body: some View {
 		HStack {
-			RustBoyButton(type: types.0, rustBoy: rustBoy, bodyView: AnyView(Arrow()))
-			RustBoyButton(type: types.1, rustBoy: rustBoy, bodyView: AnyView(Arrow()))
+            RustBoyButton(type: firstButtonType, rustBoy: rustBoy, content: Arrow.init)
+            RustBoyButton(type: secondButtonType, rustBoy: rustBoy, content: Arrow.init)
 				.rotationEffect(.degrees(180))
 		}
 	}

--- a/CommonUI/RustBoyButton.swift
+++ b/CommonUI/RustBoyButton.swift
@@ -8,11 +8,11 @@
 
 import SwiftUI
 
-internal struct RustBoyButton: View {
+internal struct RustBoyButton<ViewType>: View where ViewType: View {
 
 	internal let type: RustBoy.ButtonType
 	internal let rustBoy: RustBoy
-	internal let bodyView: AnyView
+	internal let content: () -> ViewType
 
 	@State private var touchDown: Bool = false
 
@@ -27,7 +27,7 @@ internal struct RustBoyButton: View {
 				self.rustBoy.buttonUp(self.type)
 			}
 
-		return bodyView
+		return content()
 			.opacity(touchDown ? 0.5 : 1)
 			.gesture(gesture)
 	}

--- a/CommonUI/RustBoyView.swift
+++ b/CommonUI/RustBoyView.swift
@@ -20,8 +20,8 @@ internal struct RustBoyView: View {
 				DPad(rustBoy: rustBoy)
 					.padding()
 				HStack {
-					RustBoyButton(type: .b, rustBoy: rustBoy, bodyView: AnyView(RoundButton(text: "B")))
-					RustBoyButton(type: .a, rustBoy: rustBoy, bodyView: AnyView(RoundButton(text: "A")))
+                    RustBoyButton(type: .b, rustBoy: rustBoy) { RoundButton(text: "B") }
+                    RustBoyButton(type: .a, rustBoy: rustBoy) { RoundButton(text: "A") }
 				}
 				.padding()
 			}
@@ -29,11 +29,11 @@ internal struct RustBoyView: View {
 			GeometryReader { geometry in
 				HStack {
                     VStack {
-                        RustBoyButton(type: .select, rustBoy: self.rustBoy, bodyView: AnyView(RoundedRectangle(cornerRadius: 25)))
+                        RustBoyButton(type: .select, rustBoy: self.rustBoy) { RoundedRectangle(cornerRadius: 25) }
                         Text("Select")
                     }
 					VStack {
-						RustBoyButton(type: .start, rustBoy: self.rustBoy, bodyView: AnyView(RoundedRectangle(cornerRadius: 25)))
+                        RustBoyButton(type: .start, rustBoy: self.rustBoy) { RoundedRectangle(cornerRadius: 25) }
 						Text("Start")
 					}
 				}


### PR DESCRIPTION
* Removed the need to use type-erased type `AnyView` to composite view content for `RustBoyButton`s.
* Cleaned up `HalfPad`.